### PR TITLE
Added Type definitions for Typescript compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Addon for the [react-beautiful-dnd](https://github.com/atlassian/react-beautiful
 ## Demo
 https://rokborf.github.io/natural-drag-animation-rbdnd/
 
-## Instalation
+## Installation
 ```
 # yarn
 yarn add natural-drag-animation-rbdnd

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,77 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "emitDeclarationOnly": true,
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "type",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": [
+    "src/index.jsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "type"
+  ]
+}

--- a/type/LICENSE
+++ b/type/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/type/index.d.ts
+++ b/type/index.d.ts
@@ -1,0 +1,71 @@
+// Type definitions for natural-drag-animation-rbdnd 2.1
+// Project: https://github.com/rokborf/natural-drag-animation-rbdnd#readme
+// Definitions by: Prajwal Kulkarni <https://github.com/prajwalkulkarni>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+
+import * as React from 'react'
+
+type Id = string;
+type DraggableId = Id;
+type DroppableId = Id;
+
+type MovementMode = 'FLUID' | 'SNAP';
+interface Position {
+    x: number;
+    y: number;
+}
+
+
+interface NotDraggingStyle {
+    transform?: string | undefined;
+    transition?: 'none' | undefined;
+}
+
+interface DraggingStyle {
+    position: 'fixed';
+    top: number;
+    left: number;
+    boxSizing: 'border-box';
+    width: number;
+    height: number;
+    transition: 'none';
+    transform?: string | undefined;
+    zIndex: number;
+    opacity?: number | undefined;
+    pointerEvents: 'none';
+}
+
+interface DraggableStateSnapshot {
+    isDragging: boolean;
+    isDropAnimating: boolean;
+    dropAnimation?: DropAnimation | undefined;
+    draggingOver?: DroppableId | undefined;
+    // the id of a draggable that you are combining with
+    combineWith?: DraggableId | undefined;
+    // a combine target is being dragged over by
+    combineTargetFor?: DraggableId | undefined;
+    // What type of movement is being done: 'FLUID' or 'SNAP'
+    mode?: MovementMode | undefined;
+}
+
+
+interface DropAnimation {
+    duration: number;
+    curve: string;
+    moveTo: Position;
+    opacity?: number | undefined;
+    scale?: number | undefined;
+}
+
+export interface NaturalDragAnimationType{
+    snapshot: DraggableStateSnapshot;
+    style: DraggingStyle | NotDraggingStyle | undefined;
+    animationRotationFade?: number;
+    rotationMultiplier?: number;
+    children: (style: React.CSSProperties) => React.ReactNode;
+}
+
+
+export default class NaturalDragAnimation extends React.Component<NaturalDragAnimationType> {}

--- a/type/index.d.ts.map
+++ b/type/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.jsx"],"names":[],"mappings":";AAWA;IACE;;;;;;;MAUE;IAEF;;;;MAIE;IAEF;;;;aAQC;IAED;;;;MAEE;IAGF,0BAIC;IAED,yCAQC;IAED,6BAEC;IAED,2BAoCE;IAEF,cAWC;CACF"}

--- a/type/package.json
+++ b/type/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@types/natural-drag-animation-rbdnd",
+  "version": "1.0.0",
+  "description": "TypeScript definitions for natural-drag-animation-rbdnd",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+  },
+  "contributors": [
+    {
+      "name": "Prajwal Kulkarni",
+      "url": "https://github.com/prajwalkulkarni"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
+  },
+  "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped#readme"
+}


### PR DESCRIPTION
Closes issue: #12 

This PR aims to add type definitions to support Typescript projects using this package.
To avoid external dependencies in the type definition file (`index.d.ts`), I've copied over some types required in the package from `react-beautiful-dnd`, 
e,g: `interface DraggableStateSnapshot` which is the type for the prop `snapshot`.