### PR TITLE
fix: removes build folder from main entry file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "natural-drag-animation-rbdnd",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Addon for the 'react-beautiful-dnd' that adds natural dragging animation",
-  "main": "build/index.js",
+  "main": "index.js",
   "scripts": {
     "build": "webpack --config=webpack.build.js",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
Hi,

I've had an issue in my project when using this package with vitest just like [in here](https://github.com/vitest-dev/vitest/issues/2922). Changing the `package.json` `main` line solved the issue.

Is it possible that this change will affect the bundle (could not bundle for myself)?